### PR TITLE
Add full-featured log push prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/log-battle/package.json
+++ b/log-battle/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "log-battle",
+  "version": "1.0.0",
+  "description": "Two-player log pushing game using Socket.IO",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.7.2"
+  }
+}

--- a/log-battle/public/config.js
+++ b/log-battle/public/config.js
@@ -1,0 +1,11 @@
+export const CONFIG = {
+  grid: { cols: 10, rows: 16, cell: 32, margin: 16 },
+  mana: { regenPerSec: 1, max: 10, tickMs: 100 },
+  costs: { unit: 5, building: 10 },
+  unit: { speedCellsPerSec: 3, radiusPx: 10 },
+  building: { spawnPeriodMs: 2000 },
+  log: { pushCells: 1, width: 28, height: 120, jitterMs: 120 },
+  net: { tickMs: 100 },
+  countdownSec: 3,
+};
+

--- a/log-battle/public/game.js
+++ b/log-battle/public/game.js
@@ -1,0 +1,274 @@
+import { CONFIG } from './config.js';
+import {
+  state,
+  updateLocal,
+  manaShown,
+  myMana,
+  playerId,
+  playerSide,
+} from './state.js';
+import { playCard, requestRestart } from './net.js';
+
+// canvas setup
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+canvas.width = CONFIG.grid.cols * CONFIG.grid.cell;
+canvas.height = CONFIG.grid.rows * CONFIG.grid.cell;
+
+// UI elements
+const manaText = document.getElementById('manaText');
+const manaBar = document.getElementById('manaBar');
+const unitBtn = document.getElementById('unitBtn');
+const buildingBtn = document.getElementById('buildingBtn');
+const overlay = document.getElementById('overlay');
+const overlayText = document.getElementById('overlayText');
+const newGameBtn = document.getElementById('newGame');
+
+let selectedCard = 'unit';
+let hover = { x: -1, y: -1 };
+let lastTime = performance.now();
+let prevLogJitter = 0;
+const particles = [];
+
+function selectCard(card) {
+  selectedCard = card;
+}
+
+unitBtn.addEventListener('click', () => selectCard('unit'));
+buildingBtn.addEventListener('click', () => selectCard('building'));
+
+window.addEventListener('keydown', (e) => {
+  if (e.key === '1') selectCard('unit');
+  if (e.key === '2') selectCard('building');
+  if (e.key.toLowerCase() === 'q' || e.key.toLowerCase() === 'e') {
+    cycleCard(e.key.toLowerCase() === 'q' ? -1 : 1);
+  }
+});
+
+window.addEventListener('wheel', (e) => {
+  cycleCard(e.deltaY > 0 ? 1 : -1);
+});
+
+function cycleCard(dir) {
+  const cards = ['unit', 'building'];
+  let idx = cards.indexOf(selectedCard);
+  idx = (idx + dir + cards.length) % cards.length;
+  selectedCard = cards[idx];
+}
+
+canvas.addEventListener('mousemove', (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const x = Math.floor((e.clientX - rect.left) / CONFIG.grid.cell);
+  const y = Math.floor((e.clientY - rect.top) / CONFIG.grid.cell);
+  hover = { x, y };
+});
+
+canvas.addEventListener('mouseleave', () => {
+  hover = { x: -1, y: -1 };
+});
+
+canvas.addEventListener('click', () => {
+  if (state.phase !== 'playing') return;
+  if (!canPlace(selectedCard, hover.x, hover.y)) {
+    shake(canvas);
+    return;
+  }
+  const cost = CONFIG.costs[selectedCard];
+  if (myMana() < cost) {
+    shake(selectedCard === 'unit' ? unitBtn : buildingBtn);
+    return;
+  }
+  playCard(selectedCard, hover.x, hover.y);
+});
+
+newGameBtn.addEventListener('click', () => {
+  requestRestart();
+});
+
+function canPlace(type, x, y) {
+  if (x < 0 || x >= CONFIG.grid.cols || y < 0 || y >= CONFIG.grid.rows)
+    return false;
+  if (y === state.log.y) return false;
+  if (playerSide === 'top' && y >= state.log.y) return false;
+  if (playerSide === 'bottom' && y <= state.log.y) return false;
+  if (type === 'building' && state.buildings.some((b) => b.x === x && b.y === y))
+    return false;
+  return true;
+}
+
+function shake(el) {
+  el.classList.remove('shake');
+  void el.offsetWidth; // restart animation
+  el.classList.add('shake');
+}
+
+function spawnParticles(x, y, count) {
+  for (let i = 0; i < count; i++) {
+    particles.push({
+      x,
+      y,
+      vx: (Math.random() - 0.5) * 2,
+      vy: (Math.random() - 0.5) * 2,
+      life: 300 + Math.random() * 200,
+    });
+  }
+}
+
+function updateParticles(dt) {
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const p = particles[i];
+    p.x += p.vx;
+    p.y += p.vy;
+    p.life -= dt;
+    if (p.life <= 0) particles.splice(i, 1);
+  }
+}
+
+function drawParticles() {
+  particles.forEach((p) => {
+    ctx.fillStyle = `rgba(200,150,50,${p.life / 500})`;
+    ctx.fillRect(p.x, p.y, 3, 3);
+  });
+}
+
+function update(dt) {
+  updateLocal(dt);
+  if (state.log.jitter > 0 && prevLogJitter <= 0) {
+    const lx = state.log.x * CONFIG.grid.cell + CONFIG.grid.cell / 2;
+    const ly = state.log.y * CONFIG.grid.cell;
+    spawnParticles(lx, ly, 6);
+  }
+  prevLogJitter = state.log.jitter;
+  updateParticles(dt);
+  manaText.textContent = Math.floor(manaShown);
+  const pct = manaShown / CONFIG.mana.max;
+  manaBar.style.width = pct * 100 + '%';
+
+  unitBtn.disabled = myMana() < CONFIG.costs.unit;
+  buildingBtn.disabled = myMana() < CONFIG.costs.building;
+  unitBtn.classList.toggle('selected', selectedCard === 'unit');
+  buildingBtn.classList.toggle('selected', selectedCard === 'building');
+}
+
+function drawGrid() {
+  ctx.save();
+  const bg = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  bg.addColorStop(0, '#eaeaff');
+  bg.addColorStop(1, '#d0d0ff');
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.strokeStyle = 'rgba(0,0,0,0.1)';
+  for (let i = 0; i <= CONFIG.grid.cols; i++) {
+    ctx.beginPath();
+    ctx.moveTo(i * CONFIG.grid.cell, 0);
+    ctx.lineTo(i * CONFIG.grid.cell, canvas.height);
+    ctx.stroke();
+  }
+  for (let j = 0; j <= CONFIG.grid.rows; j++) {
+    ctx.beginPath();
+    ctx.moveTo(0, j * CONFIG.grid.cell);
+    ctx.lineTo(canvas.width, j * CONFIG.grid.cell);
+    ctx.stroke();
+  }
+
+  // central line
+  ctx.strokeStyle = 'rgba(0,0,0,0.3)';
+  const midY = (CONFIG.grid.rows / 2) * CONFIG.grid.cell;
+  ctx.beginPath();
+  ctx.moveTo(0, midY);
+  ctx.lineTo(canvas.width, midY);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawLog() {
+  const jitter = state.log.jitter > 0 ? (Math.random() - 0.5) * 2 : 0;
+  const x =
+    state.log.x * CONFIG.grid.cell + CONFIG.grid.cell / 2 - CONFIG.log.width / 2;
+  const y =
+    state.log.y * CONFIG.grid.cell - CONFIG.log.height / 2 + jitter;
+  const grad = ctx.createLinearGradient(0, y, 0, y + CONFIG.log.height);
+  grad.addColorStop(0, '#c89b6a');
+  grad.addColorStop(1, '#8b5e34');
+  ctx.fillStyle = grad;
+  ctx.fillRect(x, y, CONFIG.log.width, CONFIG.log.height);
+  ctx.strokeStyle = '#5c3a1e';
+  ctx.strokeRect(x, y, CONFIG.log.width, CONFIG.log.height);
+}
+
+function drawBuildings() {
+  state.buildings.forEach((b) => {
+    const x = b.x * CONFIG.grid.cell + 4;
+    const y = b.y * CONFIG.grid.cell + 4;
+    ctx.fillStyle = '#666';
+    ctx.fillRect(x, y, CONFIG.grid.cell - 8, CONFIG.grid.cell - 8);
+  });
+}
+
+function drawUnits() {
+  state.units.forEach((u) => {
+    const ownerSide = state.players[u.owner]?.side;
+    const color = ownerSide === 'top' ? '#3a3' : '#a33';
+    const x = u.x * CONFIG.grid.cell + CONFIG.grid.cell / 2;
+    const y = u.y * CONFIG.grid.cell + CONFIG.grid.cell / 2;
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(x, y, CONFIG.unit.radiusPx, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function drawHover() {
+  if (hover.x < 0 || hover.y < 0) return;
+  const valid =
+    state.phase === 'playing' &&
+    canPlace(selectedCard, hover.x, hover.y) &&
+    myMana() >= CONFIG.costs[selectedCard];
+  ctx.fillStyle = valid ? 'rgba(0,255,0,0.3)' : 'rgba(255,0,0,0.3)';
+  ctx.fillRect(
+    hover.x * CONFIG.grid.cell,
+    hover.y * CONFIG.grid.cell,
+    CONFIG.grid.cell,
+    CONFIG.grid.cell
+  );
+}
+
+function render() {
+  drawGrid();
+  drawHover();
+  drawLog();
+  drawParticles();
+  drawBuildings();
+  drawUnits();
+
+  // overlays
+  overlay.classList.remove('visible');
+  newGameBtn.style.display = 'none';
+  if (state.phase === 'waiting') {
+    overlayText.textContent = 'Ожидание второго игрока…';
+    overlay.classList.add('visible');
+  } else if (state.phase === 'countdown') {
+    overlayText.textContent = state.countdown;
+    overlay.classList.add('visible');
+  } else if (state.phase === 'ended') {
+    overlayText.textContent =
+      state.winner === playerSide ? 'Победа!' : 'Поражение';
+    overlay.classList.add('visible');
+    newGameBtn.style.display = 'block';
+  }
+}
+
+function loop(now) {
+  const dt = now - lastTime;
+  lastTime = now;
+  update(dt);
+  render();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame((t) => {
+  lastTime = t;
+  loop(t);
+});
+

--- a/log-battle/public/index.html
+++ b/log-battle/public/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Log Push</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="ui">
+      <div>Мана: <span id="manaText">0</span></div>
+      <div id="manaContainer"><div id="manaBar"></div></div>
+      <div>
+        <button id="unitBtn">Unit (5)</button>
+        <button id="buildingBtn">Building (10)</button>
+      </div>
+    </div>
+
+    <canvas id="game"></canvas>
+
+    <div id="overlay">
+      <div id="overlayText"></div>
+      <button id="newGame">Новая игра</button>
+    </div>
+
+    <script src="/socket.io/socket.io.js"></script>
+    <script type="module" src="game.js"></script>
+  </body>
+</html>
+

--- a/log-battle/public/net.js
+++ b/log-battle/public/net.js
@@ -1,0 +1,20 @@
+import { setPlayer, applyServerState } from './state.js';
+
+export const socket = io();
+
+socket.on('joined', ({ id, side }) => {
+  setPlayer(id, side);
+});
+
+socket.on('state', (s) => {
+  applyServerState(s);
+});
+
+export function playCard(type, x, y) {
+  socket.emit('playCard', { type, x, y });
+}
+
+export function requestRestart() {
+  socket.emit('restart');
+}
+

--- a/log-battle/public/state.js
+++ b/log-battle/public/state.js
@@ -1,0 +1,40 @@
+import { CONFIG } from './config.js';
+
+export const state = {
+  phase: 'waiting',
+  players: {},
+  units: [],
+  buildings: [],
+  log: { x: 0, y: 0, jitter: 0 },
+  countdown: CONFIG.countdownSec,
+  winner: null,
+};
+
+export let playerId = null;
+export let playerSide = null;
+export let manaShown = 0;
+
+export function setPlayer(id, side) {
+  playerId = id;
+  playerSide = side;
+}
+
+export function applyServerState(s) {
+  state.phase = s.phase;
+  state.players = s.players || {};
+  state.units = s.units || [];
+  state.buildings = s.buildings || [];
+  state.log = s.log || state.log;
+  state.countdown = s.countdown;
+  state.winner = s.winner || null;
+}
+
+export function myMana() {
+  return state.players[playerId]?.mana || 0;
+}
+
+export function updateLocal(dt) {
+  const target = myMana();
+  manaShown += (target - manaShown) * Math.min(1, dt / 200);
+}
+

--- a/log-battle/public/styles.css
+++ b/log-battle/public/styles.css
@@ -1,0 +1,94 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: #222;
+  color: #fff;
+}
+
+#ui {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
+}
+
+#manaContainer {
+  width: 120px;
+  height: 12px;
+  background: #444;
+  margin-top: 4px;
+}
+
+#manaBar {
+  height: 100%;
+  width: 0%;
+  background: #4af;
+}
+
+button {
+  margin-right: 5px;
+}
+
+button.selected {
+  border: 2px solid #0f0;
+}
+
+button:disabled {
+  opacity: 0.5;
+}
+
+#overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  background: rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+#overlay.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#newGame {
+  margin-top: 20px;
+  font-size: 24px;
+}
+
+canvas {
+  display: block;
+  margin: 0 auto;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+.shake {
+  animation: shake 0.2s;
+}
+
+@keyframes shake {
+  0% {
+    transform: translate(0);
+  }
+  25% {
+    transform: translate(-5px, 0);
+  }
+  50% {
+    transform: translate(5px, 0);
+  }
+  75% {
+    transform: translate(-5px, 0);
+  }
+  100% {
+    transform: translate(0);
+  }
+}
+

--- a/log-battle/server.js
+++ b/log-battle/server.js
@@ -1,0 +1,266 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+
+// ---- configuration ----
+const CONFIG = {
+  grid: { cols: 10, rows: 16 },
+  mana: { regenPerSec: 1, max: 10 },
+  costs: { unit: 5, building: 10 },
+  unit: { speedCellsPerSec: 3 },
+  building: { spawnPeriodMs: 2000 },
+  log: { pushCells: 1, jitterMs: 120 },
+  net: { tickMs: 100 },
+  countdownSec: 3,
+};
+
+// ---- setup ----
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(__dirname + '/public'));
+
+// ---- game state ----
+const state = {
+  phase: 'waiting',
+  players: {}, // id -> {id, side, mana}
+  units: [],
+  buildings: [],
+  log: {
+    x: Math.floor(CONFIG.grid.cols / 2),
+    y: Math.floor(CONFIG.grid.rows / 2),
+    jitter: 0,
+  },
+  countdown: CONFIG.countdownSec,
+  winner: null,
+};
+
+// ---- helpers ----
+function resetForNewGame() {
+  state.units = [];
+  state.buildings = [];
+  state.log = {
+    x: Math.floor(CONFIG.grid.cols / 2),
+    y: Math.floor(CONFIG.grid.rows / 2),
+    jitter: 0,
+  };
+  state.winner = null;
+  state.countdown = CONFIG.countdownSec;
+  Object.values(state.players).forEach((p) => (p.mana = 0));
+}
+
+function startCountdown() {
+  state.phase = 'countdown';
+  state.countdown = CONFIG.countdownSec;
+}
+
+function regenMana() {
+  const gain = (CONFIG.mana.regenPerSec * CONFIG.net.tickMs) / 1000;
+  Object.values(state.players).forEach((p) => {
+    p.mana = Math.min(CONFIG.mana.max, p.mana + gain);
+  });
+}
+
+function updateBuildings() {
+  state.buildings.forEach((b) => {
+    b.spawnTimer -= CONFIG.net.tickMs;
+    if (b.spawnTimer <= 0) {
+      const owner = state.players[b.owner];
+      if (owner) {
+        const dir = owner.side === 'top' ? 1 : -1;
+        const spawnY = b.y + dir;
+        const spawnX = b.x;
+        const occupied = state.buildings.some(
+          (ob) => ob.x === spawnX && ob.y === spawnY
+        );
+        if (
+          spawnY >= 0 &&
+          spawnY < CONFIG.grid.rows &&
+          spawnY !== state.log.y &&
+          !occupied
+        ) {
+          state.units.push({
+            id: Date.now() + Math.random(),
+            x: spawnX,
+            y: spawnY,
+            owner: b.owner,
+          });
+        }
+      }
+      b.spawnTimer = CONFIG.building.spawnPeriodMs;
+    }
+  });
+}
+
+function updateUnits() {
+  const speed = (CONFIG.unit.speedCellsPerSec * CONFIG.net.tickMs) / 1000;
+  for (let i = state.units.length - 1; i >= 0; i--) {
+    const u = state.units[i];
+    const player = state.players[u.owner];
+    if (!player) {
+      state.units.splice(i, 1);
+      continue;
+    }
+    if (player.side === 'top') {
+      u.y += speed;
+      if (u.y >= state.log.y) {
+        state.log.y = Math.min(
+          CONFIG.grid.rows - 1,
+          state.log.y + CONFIG.log.pushCells
+        );
+        state.log.jitter = CONFIG.log.jitterMs;
+        state.units.splice(i, 1);
+        continue;
+      }
+    } else {
+      u.y -= speed;
+      if (u.y <= state.log.y) {
+        state.log.y = Math.max(0, state.log.y - CONFIG.log.pushCells);
+        state.log.jitter = CONFIG.log.jitterMs;
+        state.units.splice(i, 1);
+        continue;
+      }
+    }
+    if (u.y < 0 || u.y > CONFIG.grid.rows - 1) {
+      state.units.splice(i, 1);
+    }
+  }
+}
+
+function reduceLogJitter() {
+  if (state.log.jitter > 0) {
+    state.log.jitter = Math.max(0, state.log.jitter - CONFIG.net.tickMs);
+  }
+}
+
+function checkWin() {
+  if (state.log.y <= 0) {
+    state.phase = 'ended';
+    state.winner = 'bottom';
+  } else if (state.log.y >= CONFIG.grid.rows - 1) {
+    state.phase = 'ended';
+    state.winner = 'top';
+  }
+}
+
+function sendState() {
+  io.emit('state', {
+    phase: state.phase,
+    countdown: Math.ceil(state.countdown),
+    players: state.players,
+    units: state.units,
+    buildings: state.buildings,
+    log: state.log,
+    winner: state.winner,
+  });
+}
+
+function isValidPlacement(player, type, x, y) {
+  if (x < 0 || x >= CONFIG.grid.cols || y < 0 || y >= CONFIG.grid.rows)
+    return false;
+  if (y === state.log.y) return false;
+  if (player.side === 'top' && y >= state.log.y) return false;
+  if (player.side === 'bottom' && y <= state.log.y) return false;
+  if (type === 'building') {
+    if (state.buildings.some((b) => b.x === x && b.y === y)) return false;
+  }
+  return true;
+}
+
+// ---- game loop ----
+function gameTick() {
+  if (state.phase === 'countdown') {
+    state.countdown -= CONFIG.net.tickMs / 1000;
+    if (state.countdown <= 0) {
+      state.phase = 'playing';
+    }
+  }
+
+  if (state.phase === 'playing') {
+    regenMana();
+    updateBuildings();
+    updateUnits();
+    reduceLogJitter();
+    checkWin();
+  }
+
+  sendState();
+}
+
+setInterval(gameTick, CONFIG.net.tickMs);
+
+// ---- socket handling ----
+io.on('connection', (socket) => {
+  if (Object.keys(state.players).length >= 2) {
+    socket.emit('full');
+    socket.disconnect();
+    return;
+  }
+
+  const side =
+    Object.values(state.players).find((p) => p.side === 'top') ? 'bottom' : 'top';
+  state.players[socket.id] = { id: socket.id, side, mana: 0 };
+  socket.emit('joined', { id: socket.id, side });
+
+  if (
+    Object.keys(state.players).length === 2 &&
+    (state.phase === 'waiting' || state.phase === 'ended')
+  ) {
+    resetForNewGame();
+    startCountdown();
+  }
+
+  socket.on('playCard', ({ type, x, y }) => {
+    if (state.phase !== 'playing') return;
+    const player = state.players[socket.id];
+    if (!player) return;
+
+    if (type === 'unit') {
+      if (player.mana < CONFIG.costs.unit) return;
+      if (!isValidPlacement(player, 'unit', x, y)) return;
+      player.mana -= CONFIG.costs.unit;
+      state.units.push({
+        id: Date.now() + Math.random(),
+        x,
+        y,
+        owner: socket.id,
+      });
+    } else if (type === 'building') {
+      if (player.mana < CONFIG.costs.building) return;
+      if (!isValidPlacement(player, 'building', x, y)) return;
+      player.mana -= CONFIG.costs.building;
+      state.buildings.push({
+        id: Date.now() + Math.random(),
+        x,
+        y,
+        owner: socket.id,
+        spawnTimer: CONFIG.building.spawnPeriodMs,
+      });
+    }
+  });
+
+  socket.on('restart', () => {
+    if (state.phase === 'ended') {
+      resetForNewGame();
+      if (Object.keys(state.players).length === 2) {
+        startCountdown();
+      } else {
+        state.phase = 'waiting';
+      }
+    }
+  });
+
+  socket.on('disconnect', () => {
+    delete state.players[socket.id];
+    state.phase = 'waiting';
+    sendState();
+  });
+});
+
+// ---- start server ----
+server.listen(PORT, () => {
+  console.log('Server running on port', PORT);
+});
+


### PR DESCRIPTION
## Summary
- implement server phases with countdown, mana regeneration and validated card placement
- add modular client with canvas rendering, overlays and particle effects
- configure game balance constants and UI styling for mana and card selection

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `node server.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68a20f66d094832fadec6a6e393ebee4